### PR TITLE
Feature/source name for source info query

### DIFF
--- a/server/src/resolvers/Query/pyrog.ts
+++ b/server/src/resolvers/Query/pyrog.ts
@@ -18,15 +18,21 @@ export const pyrogQuery = {
   // CLIENT QUERIES
   // Information queries
   sourceInfo(parent, { sourceId, sourceName }, context: Context) {
+    getUserId(context);
+
     if (sourceName) {
       return context.client.source({ name: sourceName });
     }
     return context.client.source({ id: sourceId });
   },
   resourceInfo(parent, { resourceId }, context: Context) {
+    getUserId(context);
+
     return context.client.resource({ id: resourceId });
   },
   attributeInfo(parent, { attributeId }, context: Context) {
+    getUserId(context);
+
     return context.client.attribute({ id: attributeId });
   },
   allSources(parent, args, context: Context) {

--- a/server/src/resolvers/Query/pyrog.ts
+++ b/server/src/resolvers/Query/pyrog.ts
@@ -17,7 +17,10 @@ export const pyrogQuery = {
 
   // CLIENT QUERIES
   // Information queries
-  sourceInfo(parent, { sourceId }, context: Context) {
+  sourceInfo(parent, { sourceId, sourceName }, context: Context) {
+    if (sourceName) {
+      return context.client.source({ name: sourceName });
+    }
     return context.client.source({ id: sourceId });
   },
   resourceInfo(parent, { resourceId }, context: Context) {

--- a/server/src/schema.graphql
+++ b/server/src/schema.graphql
@@ -7,7 +7,7 @@ type Query {
   resources(where: ResourceWhereInput): [Resource]!
 
   # CLIENT QUERIES
-  sourceInfo(sourceId: ID!): Source!
+  sourceInfo(sourceId: ID, sourceName: String): Source!
   resourceInfo(resourceId: ID!): Resource!
   attributeInfo(attributeId: ID!): Attribute!
   allSources: [Source!]!

--- a/server/test/schema.test.js
+++ b/server/test/schema.test.js
@@ -162,6 +162,20 @@ describe("Graphql server", () => {
         }
       });
     });
+
+    test("sourceInfo", async () => {
+      expect(
+        await sendPostRequest(
+          `query { sourceInfo(sourceName: "Mimic") { id name }}`,
+          {},
+          token
+        )
+      ).toEqual({
+        data: {
+          sourceInfo: expect.objectContaining({ name: "Mimic" })
+        }
+      });
+    });
   });
 
   describe("Mutations", () => {


### PR DESCRIPTION
- `sourceInfo` can now receive a `sourceName` param instead of a `sourceId` param ; this is useful for `fhir-pipe`
- now check that `sourceInfo` and co check user's authentication