### PR TITLE
Fix array building in tree

### DIFF
--- a/client/src/components/mapping/FhirMappingPanel/FhirResourceTree/index.tsx
+++ b/client/src/components/mapping/FhirMappingPanel/FhirResourceTree/index.tsx
@@ -194,18 +194,11 @@ const FhirResourceTree = ({ onClickCallback }: Props) => {
     definition: any
   ): ITreeNode<Node>[] => {
     // Check if there are already existing attributes for this node
-    const endNodeKey = parent.serialize().length + 1;
-    // We use Set to remove duplicate ids
     // we extract the index from the path
-    let existingChildrenIndices = [
-      ...new Set(
-        Object.keys(attributesForResource)
-          .filter(key => key.startsWith(parent.serialize()))
-          .map(key =>
-            Number(key.substring(endNodeKey, key.indexOf(']', endNodeKey)))
-          )
-      )
-    ];
+    const regex = new RegExp(`^${parent.serialize()}\\[(\\d+)\\]$`);
+    let existingChildrenIndices = Object.keys(attributesForResource)
+      .filter(key => regex.test(key))
+      .map(key => Number(regex.exec(key)![1]));
 
     if (existingChildrenIndices.length === 0) {
       // If no child exists yet, we still build one with index 0

--- a/client/src/components/mapping/TabColumnPicking/DynamicColumnPicker/index.tsx
+++ b/client/src/components/mapping/TabColumnPicking/DynamicColumnPicker/index.tsx
@@ -111,7 +111,7 @@ const DynamicColumnPicker = ({ attribute, schema, source }: Props) => {
       const parentPath = curNode.path;
       if (
         !attributesForResource[parentPath] &&
-        !(curNode.parent && curNode.parent.isArray) &&
+        !curNode.isArray &&
         !(curNode.types.length > 1)
       ) {
         const { data: attr } = await createAttribute({

--- a/client/src/components/mapping/TabColumnPicking/StaticValueForm/index.tsx
+++ b/client/src/components/mapping/TabColumnPicking/StaticValueForm/index.tsx
@@ -112,7 +112,7 @@ const StaticValueForm = ({ attribute }: Props) => {
       const parentPath = curNode.path;
       if (
         !attributesForResource[parentPath] &&
-        !(curNode.parent && curNode.parent.isArray) &&
+        !curNode.isArray &&
         !(curNode.types.length > 1)
       ) {
         const { data: attr } = await createAttribute({


### PR DESCRIPTION
Before, for an array attribute (eg maritalStatus.coding), we stored an attribute with path `maritalStatus.coding`. Now, we store `maritalStatus.coding[i]` for each element in this array attribute.

This makes it easier, in `buildChildNodesForArray()` to know how many elements for array attributes we have to build.