### PR TITLE
Run fhirpipe with resource ids and display errors on preview

### DIFF
--- a/client/src/components/fhirpipe/index.tsx
+++ b/client/src/components/fhirpipe/index.tsx
@@ -114,9 +114,7 @@ const FhirpipeView = () => {
     // chunksize, bypass_validation, multiprocessing
     // It is also needed to provide credentialId
     const body = {
-      source: selectedSource.name,
-      resources: selectedResources.map(r => r.definitionId),
-      labels: selectedResources.map(r => r.label),
+      resource_ids: selectedResources.map(r => r.id),
       credentialId: credentials && credentials.id,
       bypass_validation: bypassValidation,
       override: override,

--- a/client/src/components/fhirpipe/index.tsx
+++ b/client/src/components/fhirpipe/index.tsx
@@ -42,6 +42,7 @@ const FhirpipeView = () => {
   const [selectedSource, setSelectedSource] = useState({} as Source);
   const [selectedResources, setSelectedResources] = useState([] as Resource[]);
   const [bypassValidation, setBypassValidation] = useState(false);
+  const [skipRefBinding, setSkipRefBinding] = useState(false);
   const [override, setOverride] = useState(false);
   const [multiprocessing, setMultiprocessing] = useState(false);
   const [running, setRunning] = useState(false);
@@ -117,6 +118,7 @@ const FhirpipeView = () => {
       resource_ids: selectedResources.map(r => r.id),
       credentialId: credentials && credentials.id,
       bypass_validation: bypassValidation,
+      skip_ref_binding: skipRefBinding,
       override: override,
       multiprocessing: multiprocessing
     };
@@ -215,6 +217,11 @@ const FhirpipeView = () => {
                 checked={bypassValidation}
                 label="bypass_validation"
                 onChange={(): void => setBypassValidation(prev => !prev)}
+              />
+              <Switch
+                checked={skipRefBinding}
+                label="skip_reference_binding"
+                onChange={(): void => setSkipRefBinding(prev => !prev)}
               />
               <Switch
                 checked={multiprocessing}

--- a/client/src/components/mapping/TabColumnPicking/DynamicColumnPicker/FhirPreview/index.tsx
+++ b/client/src/components/mapping/TabColumnPicking/DynamicColumnPicker/FhirPreview/index.tsx
@@ -14,6 +14,9 @@ const FhirPreview = ({ rowId }: Props) => {
   const toaster = useSelector((state: IReduxStore) => state.toaster);
   const { resource } = useSelector((state: IReduxStore) => state.selectedNode);
   const [fhirObject, setFhirObject] = React.useState(undefined as any);
+  const [validationErrors, setValidationErrors] = React.useState(
+    [] as string[]
+  );
   const [loading, setLoading] = React.useState(true);
 
   React.useEffect(() => {
@@ -23,7 +26,8 @@ const FhirPreview = ({ rowId }: Props) => {
         const res = await axios.get(
           `${FHIRPIPE_URL}/preview/${resource.id}/${rowId}`
         );
-        setFhirObject(res.data);
+        setFhirObject(res.data.preview);
+        setValidationErrors(res.data.errors);
         setLoading(false);
       } catch (err) {
         toaster.show({
@@ -39,7 +43,22 @@ const FhirPreview = ({ rowId }: Props) => {
 
   if (loading) return <Spinner />;
 
-  return <pre>{JSON.stringify(fhirObject, null, 4)}</pre>;
+  const renderValidationErrors = () => (
+    <React.Fragment>
+      <h3> Validation errors </h3>
+      {validationErrors.map((error, ind) => (
+        <pre key={ind}>{error}</pre>
+      ))}
+    </React.Fragment>
+  );
+
+  return (
+    <div>
+      {validationErrors.length > 0 && renderValidationErrors()}
+      <h3> Fhir instance preview </h3>
+      <pre>{JSON.stringify(fhirObject, null, 4)}</pre>
+    </div>
+  );
 };
 
 export default FhirPreview;


### PR DESCRIPTION
Catch up with the latest versions of Fhirpipe.
- Run uses resource ids
- Preview response contains validation errors if any.

Preview display:
![Capture d’écran 2020-03-25 à 12 05 35](https://user-images.githubusercontent.com/19286277/77530295-627e9e80-6e91-11ea-9362-8f862e6b3ffd.png)
