### PR TITLE
Admin can see all sources (and cache user in redis)

### DIFF
--- a/server/src/cache.ts
+++ b/server/src/cache.ts
@@ -5,6 +5,7 @@ import { REDIS_URL } from './constants'
 
 let rcache: RedisClient
 let get: (arg: string) => Promise<string>
+let del: (arg: string) => Promise<number>
 let mget: OverloadedKeyCommand<string[], string[], Promise<string[]>>
 let set: (arg1: string, arg2: string) => Promise<unknown>
 let sadd: OverloadedKeyCommand<string, number, Promise<number>>
@@ -17,6 +18,7 @@ export default () => {
   if (rcache)
     return {
       get,
+      del,
       mget,
       set,
       sadd,
@@ -24,6 +26,7 @@ export default () => {
     }
   rcache = redis.createClient({ url: REDIS_URL })
   get = promisify(rcache.get).bind(rcache)
+  del = promisify(rcache.del).bind(rcache)
   mget = promisify(rcache.mget).bind(rcache)
   set = promisify(rcache.set).bind(rcache)
   sadd = promisify(rcache.sadd).bind(rcache)

--- a/server/src/context.ts
+++ b/server/src/context.ts
@@ -1,15 +1,17 @@
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient, User } from '@prisma/client'
 import { ContextParameters } from 'graphql-yoga/dist/types'
+import { getUser } from 'utils'
+
 const prisma = new PrismaClient()
 
 export interface Context {
   prisma: PrismaClient
   request: any
+  user?: User
 }
 
-export function createContext(request: ContextParameters) {
-  return {
-    ...request,
-    prisma,
-  }
-}
+export const createContext = async (context: ContextParameters) => ({
+  ...context,
+  prisma,
+  user: await getUser(context.request),
+})

--- a/server/src/permissions/index.ts
+++ b/server/src/permissions/index.ts
@@ -1,37 +1,31 @@
 import { rule, shield } from 'graphql-shield'
 
-import { getUserId } from 'utils'
+import { getUser } from 'utils'
 import { Context } from 'context'
 import { getSourceIdFromMutationArgs } from './resolvers'
 
 const rules = {
   isAuthenticatedUser: rule()((_, __, ctx: Context) => {
-    const userId = getUserId(ctx)
-    return Boolean(userId)
+    return !!ctx.user
   }),
   isAdmin: rule()(async (_, __, ctx: Context) => {
-    const userId = getUserId(ctx)
-    const user = await ctx.prisma.user.findOne({
-      where: { id: userId },
-    })
+    const { user } = ctx
     return Boolean(user && user.role == 'ADMIN')
   }),
   isSourceReader: rule()(async (_, args, ctx: Context) => {
     // Get user id
-    const userId = getUserId(ctx)
+    const { user } = ctx
+    if (!user) return false
 
     // Return true if the user is admin
-    const user = await ctx.prisma.user.findOne({
-      where: { id: userId },
-    })
-    if (user && user.role == 'ADMIN') return true
+    if (user.role == 'ADMIN') return true
 
     let sourceId = getSourceIdFromMutationArgs(args, ctx)
 
     // Check access
     const access = await ctx.prisma.accessControl.findMany({
       where: {
-        user: { id: userId },
+        user: { id: user.id },
         source: { id: sourceId },
       },
     })
@@ -39,20 +33,18 @@ const rules = {
   }),
   isSourceWriter: rule()(async (_, args, ctx: Context) => {
     // Get user id
-    const userId = getUserId(ctx)
+    const { user } = ctx
+    if (!user) return false
 
     // Return true if the user is admin
-    const user = await ctx.prisma.user.findOne({
-      where: { id: userId },
-    })
-    if (user && user.role == 'ADMIN') return true
+    if (user.role == 'ADMIN') return true
 
     let sourceId = getSourceIdFromMutationArgs(args, ctx)
 
     // Check role
     const access = await ctx.prisma.accessControl.findMany({
       where: {
-        user: { id: userId },
+        user: { id: user.id },
         source: { id: sourceId },
         role: 'WRITER',
       },

--- a/server/src/permissions/index.ts
+++ b/server/src/permissions/index.ts
@@ -1,6 +1,5 @@
 import { rule, shield } from 'graphql-shield'
 
-import { getUser } from 'utils'
 import { Context } from 'context'
 import { getSourceIdFromMutationArgs } from './resolvers'
 

--- a/server/src/resolvers/Query.ts
+++ b/server/src/resolvers/Query.ts
@@ -1,7 +1,6 @@
 import { arg, idArg, queryType } from '@nexus/schema'
 
 import { getDefinition } from 'fhir'
-import { getUserId } from 'utils'
 import { sources } from './Source'
 import { searchDefinitions } from './StructureDefinition'
 
@@ -10,14 +9,7 @@ export const Query = queryType({
     t.field('me', {
       type: 'User',
       nullable: true,
-      resolve: async (parent, args, ctx) => {
-        const userId = getUserId(ctx)
-        return ctx.prisma.user.findOne({
-          where: {
-            id: userId,
-          },
-        })
-      },
+      resolve: async (_, __, ctx) => ctx.user || null,
     })
 
     t.field('credential', {

--- a/server/src/resolvers/Source.ts
+++ b/server/src/resolvers/Source.ts
@@ -1,7 +1,6 @@
 import { objectType, FieldResolver } from '@nexus/schema'
 
 import { importMapping, exportMapping } from 'resolvers/mapping'
-import { userInfo } from 'os'
 
 export const Source = objectType({
   name: 'Source',

--- a/server/src/resolvers/Source.ts
+++ b/server/src/resolvers/Source.ts
@@ -1,7 +1,7 @@
 import { objectType, FieldResolver } from '@nexus/schema'
 
 import { importMapping, exportMapping } from 'resolvers/mapping'
-import { getUserId } from 'utils'
+import { userInfo } from 'os'
 
 export const Source = objectType({
   name: 'Source',
@@ -57,12 +57,13 @@ export const sources: FieldResolver<'Query', 'sources'> = async (
   _args,
   ctx,
 ) => {
-  const userId = getUserId(ctx)
-  const accesses = await ctx.prisma.accessControl.findMany({
-    where: { user: { id: userId } },
-    include: { source: true },
+  const { role, id } = ctx.user!
+
+  if (role === 'ADMIN') return ctx.prisma.source.findMany()
+
+  return ctx.prisma.source.findMany({
+    where: { accessControls: { some: { user: { id } } } },
   })
-  return accesses.map(a => a.source)
 }
 
 export const createSource: FieldResolver<'Mutation', 'createSource'> = async (
@@ -90,10 +91,9 @@ export const createSource: FieldResolver<'Mutation', 'createSource'> = async (
   })
 
   // create a row in ACL
-  const userId = getUserId(ctx)
   await ctx.prisma.accessControl.create({
     data: {
-      user: { connect: { id: userId } },
+      user: { connect: { id: ctx.user!.id } },
       source: { connect: { id: source.id } },
       role: 'WRITER',
     },

--- a/server/src/resolvers/User.ts
+++ b/server/src/resolvers/User.ts
@@ -38,6 +38,7 @@ export const login: FieldResolver<'Mutation', 'login'> = async (
   }
 
   // cache user in redis
+  // TODO: remove user from cache on logout
   const { set } = cache()
   await set(`user:${user.id}`, JSON.stringify(user))
 

--- a/server/src/resolvers/User.ts
+++ b/server/src/resolvers/User.ts
@@ -3,6 +3,7 @@ import { compare, hash } from 'bcryptjs'
 import { sign } from 'jsonwebtoken'
 
 import { APP_SECRET } from '../constants'
+import cache from 'cache'
 
 export const User = objectType({
   name: 'User',
@@ -35,6 +36,11 @@ export const login: FieldResolver<'Mutation', 'login'> = async (
   if (!passwordValid) {
     throw new Error('Invalid password')
   }
+
+  // cache user in redis
+  const { set } = cache()
+  await set(`user:${user.id}`, JSON.stringify(user))
+
   return {
     token: sign({ userId: user.id }, APP_SECRET!),
     user,
@@ -54,6 +60,11 @@ export const signup: FieldResolver<'Mutation', 'signup'> = async (
       password: hashedPassword,
     },
   })
+
+  // cache user in redis
+  const { set } = cache()
+  await set(`user:${user.id}`, JSON.stringify(user))
+
   return {
     token: sign({ userId: user.id }, APP_SECRET!),
     user,

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -1,21 +1,29 @@
 import * as crypto from 'crypto'
-
 import { verify } from 'jsonwebtoken'
+import { User } from '@prisma/client'
 
-import { Context } from './context'
 import { APP_SECRET, IV } from './constants'
+import cache from 'cache'
+import { Request } from 'express'
 
 interface Token {
   userId: string
 }
 
-export function getUserId(context: Context) {
-  const Authorization = context.request.get('Authorization')
+export const getUser = async (request: Request): Promise<User | null> => {
+  const Authorization = request.get('Authorization')
   if (Authorization) {
     const token = Authorization.replace('Bearer ', '')
     const verifiedToken = verify(token, APP_SECRET!) as Token
-    return verifiedToken && verifiedToken.userId
+    if (!!verifiedToken) {
+      const { get } = cache()
+
+      const cached = await get(`user:${verifiedToken.userId}`)
+      const user: User = JSON.parse(cached)
+      return user
+    }
   }
+  return null
 }
 
 export const encrypt = (text: string) => {


### PR DESCRIPTION
user is cached in redis on login/signup
user is put in context for every request (if auth token is ok)

update the `sources` resolver so that admins can see all sources