### PR TITLE
Enable custom identifier system

### DIFF
--- a/client/src/components/fhirpipe/index.tsx
+++ b/client/src/components/fhirpipe/index.tsx
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { Button, MenuItem, Switch } from '@blueprintjs/core';
+import { Button, Switch } from '@blueprintjs/core';
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useQuery } from '@apollo/react-hooks';

--- a/client/src/components/fhirpipe/index.tsx
+++ b/client/src/components/fhirpipe/index.tsx
@@ -50,7 +50,7 @@ const FhirpipeView = (): React.ReactElement => {
   const [running, setRunning] = useState(false);
 
   const { data } = useQuery(qSourcesAndResources, {
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'no-cache'
   });
 
   const sources = data ? data.sources : [];

--- a/client/src/components/fhirpipe/index.tsx
+++ b/client/src/components/fhirpipe/index.tsx
@@ -56,7 +56,6 @@ const FhirpipeView = (): React.ReactElement => {
   const sources = data ? data.sources : [];
   const credentials = selectedSource.id ? selectedSource.credential : undefined;
   const credentialsMissing = !!selectedSource.id && !credentials;
-  // const ResourceMultiSelect = MultiSelect.ofType<Resource>();
 
   const isItemSelected = (list: any[], item: any): boolean => {
     return list.includes(item);

--- a/client/src/components/mapping/FhirMappingPanel/FhirResourceTree/index.tsx
+++ b/client/src/components/mapping/FhirMappingPanel/FhirResourceTree/index.tsx
@@ -3,7 +3,6 @@ import { useApolloClient, useMutation } from '@apollo/react-hooks';
 import { Classes, Icon, ITreeNode, Tree } from '@blueprintjs/core';
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { ApolloError } from 'apollo-client/errors/ApolloError';
 import { useQuery } from '@apollo/react-hooks';
 import { IReduxStore } from 'types';
 import { loader } from 'graphql.macro';

--- a/client/src/components/mapping/TabColumnPicking/StaticValueForm/IdentifierSystemInput/index.tsx
+++ b/client/src/components/mapping/TabColumnPicking/StaticValueForm/IdentifierSystemInput/index.tsx
@@ -46,6 +46,7 @@ const IdentifierSystemInput = ({
 
   const [staticValue, setStaticValue] = useState('');
   const [customSystem, setCustomSystem] = useState(false);
+  const [customKeyName, setCustomKeyName] = useState('');
   const [selectedSource, setSelectedSource] = useState(
     undefined as Source | undefined
   );
@@ -89,6 +90,14 @@ const IdentifierSystemInput = ({
               selectedSource === undefined || attribute.parent?.isRootIdentifier
             }
           />
+          <InputGroup
+            onChange={(event: React.FormEvent<HTMLElement>): void => {
+              const target = event.target as HTMLInputElement;
+              setCustomKeyName(target.value);
+            }}
+            placeholder="Custom key name"
+            value={customKeyName}
+          />
         </>
       ) : (
         <InputGroup
@@ -111,7 +120,7 @@ const IdentifierSystemInput = ({
           addStaticValue(
             `http://terminology.arkhn.org/${selectedSource!.id}/${
               selectedResource!.id
-            }`
+            }${customKeyName ? '/' + customKeyName : ''}`
           )
         }
       />

--- a/client/src/components/mapping/TabColumnPicking/StaticValueForm/IdentifierSystemInput/index.tsx
+++ b/client/src/components/mapping/TabColumnPicking/StaticValueForm/IdentifierSystemInput/index.tsx
@@ -40,9 +40,6 @@ const IdentifierSystemInput = ({
   creatingStaticInput,
   addStaticValue
 }: Props): React.ReactElement => {
-  // If the current attribute is the identifier of the resource and not a Reference identifier
-  const isRootIdentifierSystem = !attribute.parent?.parent;
-
   const { source, resource } = useSelector(
     (state: IReduxStore) => state.selectedNode
   );
@@ -57,7 +54,7 @@ const IdentifierSystemInput = ({
   );
 
   useEffect(() => {
-    if (isRootIdentifierSystem) {
+    if (attribute.parent?.isRootIdentifier) {
       setSelectedSource(source);
       setSelectedResource(resource);
     } else {
@@ -82,13 +79,15 @@ const IdentifierSystemInput = ({
             items={sources}
             onChange={handleSourceSelect}
             inputItem={selectedSource || ({} as Source)}
-            disabled={isRootIdentifierSystem}
+            disabled={attribute.parent?.isRootIdentifier}
           />
           <ResourceSelect
             items={selectedSource?.resources || []}
             onChange={handleResourceSelect}
             inputItem={selectedResource || ({} as Resource)}
-            disabled={selectedSource === undefined || isRootIdentifierSystem}
+            disabled={
+              selectedSource === undefined || attribute.parent?.isRootIdentifier
+            }
           />
         </>
       ) : (

--- a/client/src/components/mapping/TabColumnPicking/StaticValueForm/IdentifierSystemInput/index.tsx
+++ b/client/src/components/mapping/TabColumnPicking/StaticValueForm/IdentifierSystemInput/index.tsx
@@ -64,7 +64,7 @@ const IdentifierSystemInput = ({
       setSelectedSource(undefined);
       setSelectedResource(undefined);
     }
-  }, [attribute]);
+  }, [attribute, source, resource]);
 
   const handleSourceSelect = (source: Source): void => {
     setSelectedSource(source);

--- a/client/src/components/mapping/TabColumnPicking/StaticValueForm/IdentifierSystemInput/index.tsx
+++ b/client/src/components/mapping/TabColumnPicking/StaticValueForm/IdentifierSystemInput/index.tsx
@@ -19,7 +19,6 @@ import ResourceSelect from 'components/selects/resourceSelect';
 import { Resource } from 'types';
 
 interface Props {
-  // TODO real types
   attribute: Attribute;
   sources: Source[];
   creatingStaticInput: boolean;
@@ -41,6 +40,9 @@ const IdentifierSystemInput = ({
   creatingStaticInput,
   addStaticValue
 }: Props): React.ReactElement => {
+  // If the current attribute is the identifier of the resource and not a Reference identifier
+  const isRootIdentifierSystem = !attribute.parent?.parent;
+
   const { source, resource } = useSelector(
     (state: IReduxStore) => state.selectedNode
   );
@@ -54,11 +56,8 @@ const IdentifierSystemInput = ({
     undefined as Resource | undefined
   );
 
-  // If the current attribute is the identifier of the resource and not a Reference identifier
-  const isIdentifierSystem = /^identifier\[\d+\]\.system$/.test(attribute.path);
-
   useEffect(() => {
-    if (isIdentifierSystem) {
+    if (isRootIdentifierSystem) {
       setSelectedSource(source);
       setSelectedResource(resource);
     } else {
@@ -83,13 +82,13 @@ const IdentifierSystemInput = ({
             items={sources}
             onChange={handleSourceSelect}
             inputItem={selectedSource || ({} as Source)}
-            disabled={isIdentifierSystem}
+            disabled={isRootIdentifierSystem}
           />
           <ResourceSelect
             items={selectedSource?.resources || []}
             onChange={handleResourceSelect}
             inputItem={selectedResource || ({} as Resource)}
-            disabled={selectedSource === undefined || isIdentifierSystem}
+            disabled={selectedSource === undefined || isRootIdentifierSystem}
           />
         </>
       ) : (

--- a/client/src/components/mapping/TabColumnPicking/StaticValueForm/IdentifierSystemInput/index.tsx
+++ b/client/src/components/mapping/TabColumnPicking/StaticValueForm/IdentifierSystemInput/index.tsx
@@ -103,7 +103,10 @@ const IdentifierSystemInput = ({
         />
       )}
       <Button
-        disabled={customSystem && selectedResource === undefined}
+        disabled={
+          (customSystem && selectedResource === undefined) ||
+          (!customSystem && staticValue.length === 0)
+        }
         icon={'add'}
         loading={creatingStaticInput}
         onClick={() =>

--- a/client/src/components/mapping/TabColumnPicking/StaticValueForm/IdentifierSystemInput/index.tsx
+++ b/client/src/components/mapping/TabColumnPicking/StaticValueForm/IdentifierSystemInput/index.tsx
@@ -1,0 +1,148 @@
+import {
+  Button,
+  Checkbox,
+  ControlGroup,
+  InputGroup,
+  Popover,
+  Position
+} from '@blueprintjs/core';
+import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { IReduxStore } from 'types';
+
+import { Attribute } from '@arkhn/fhir.ts';
+
+import SourceSelect from 'components/selects/sourceSelect';
+import ResourceSelect from 'components/selects/resourceSelect';
+
+import { Resource } from 'types';
+
+interface Props {
+  // TODO real types
+  attribute: Attribute;
+  sources: Source[];
+  creatingStaticInput: boolean;
+  addStaticValue: (value: string) => Promise<void>;
+}
+
+interface Source {
+  id: string;
+  name: string;
+  template: {
+    name: string;
+  };
+  resources: Resource[];
+}
+
+const IdentifierSystemInput = ({
+  attribute,
+  sources,
+  creatingStaticInput,
+  addStaticValue
+}: Props): React.ReactElement => {
+  const { source, resource } = useSelector(
+    (state: IReduxStore) => state.selectedNode
+  );
+
+  const [staticValue, setStaticValue] = useState('');
+  const [customSystem, setCustomSystem] = useState(false);
+  const [selectedSource, setSelectedSource] = useState(
+    undefined as Source | undefined
+  );
+  const [selectedResource, setSelectedResource] = useState(
+    undefined as Resource | undefined
+  );
+
+  // If the current attribute is the identifier of the resource and not a Reference identifier
+  const isIdentifierSystem = /^identifier\[\d+\]\.system$/.test(attribute.path);
+
+  useEffect(() => {
+    if (isIdentifierSystem) {
+      setSelectedSource(source);
+      setSelectedResource(resource);
+    } else {
+      setSelectedSource(undefined);
+      setSelectedResource(undefined);
+    }
+  }, [attribute]);
+
+  const handleSourceSelect = (source: Source): void => {
+    setSelectedSource(source);
+    setSelectedResource(undefined);
+  };
+  const handleResourceSelect = (resource: Resource): void => {
+    setSelectedResource(resource);
+  };
+
+  return (
+    <ControlGroup>
+      {customSystem ? (
+        <>
+          <SourceSelect
+            items={sources}
+            onChange={handleSourceSelect}
+            inputItem={selectedSource || ({} as Source)}
+            disabled={isIdentifierSystem}
+          />
+          <ResourceSelect
+            items={selectedSource?.resources || []}
+            onChange={handleResourceSelect}
+            inputItem={selectedResource || ({} as Resource)}
+            disabled={selectedSource === undefined || isIdentifierSystem}
+          />
+        </>
+      ) : (
+        <InputGroup
+          onChange={(event: React.FormEvent<HTMLElement>): void => {
+            const target = event.target as HTMLInputElement;
+            setStaticValue(target.value);
+          }}
+          placeholder="Static input"
+          value={staticValue}
+        />
+      )}
+      <Button
+        disabled={customSystem && selectedResource === undefined}
+        icon={'add'}
+        loading={creatingStaticInput}
+        onClick={() =>
+          addStaticValue(
+            `http://terminology.arkhn.org/${selectedSource!.id}/${
+              selectedResource!.id
+            }`
+          )
+        }
+      />
+      <Checkbox
+        className="custom-checkbox"
+        checked={customSystem}
+        label="Custom system"
+        onChange={(): void => setCustomSystem(!customSystem)}
+      />
+      <Popover
+        interactionKind="hover"
+        boundary="viewport"
+        className="help-popover"
+        position={Position.BOTTOM_RIGHT}
+      >
+        <Button icon="help" minimal={true} small={true} />
+        {
+          <div>
+            <p className="text">
+              The identifier system is a URI that defines a set of identifiers
+              (i.e. how the value is made unique). For istance, we use
+              "http://hl7.org/fhir/sid/us-ssn" for United States Social Security
+              Number (SSN) identifier values. Sometimes, the identifiers are not
+              a recognized standard so we need to use a custom system. Pyrog's
+              custom systems have the form
+              "http://terminology.arkhn.org/sourceId/resourceId".
+            </p>
+          </div>
+        }
+      </Popover>
+    </ControlGroup>
+  );
+};
+
+export default IdentifierSystemInput;

--- a/client/src/components/mapping/TabColumnPicking/StaticValueForm/index.tsx
+++ b/client/src/components/mapping/TabColumnPicking/StaticValueForm/index.tsx
@@ -71,7 +71,10 @@ const StaticValueForm = ({ attribute }: Props): React.ReactElement => {
     }
   }, [attribute]);
 
-  const addInputToCache = (cache: any, { data: { createInput } }: any) => {
+  const addInputToCache = (
+    cache: any,
+    { data: { createInput } }: any
+  ): void => {
     try {
       const { attribute: dataAttribute } = cache.readQuery({
         query: qInputsForAttribute,
@@ -177,7 +180,6 @@ const StaticValueForm = ({ attribute }: Props): React.ReactElement => {
   const renderTextInput = (): React.ReactElement => (
     <React.Fragment>
       <InputGroup
-        id="static-value-input"
         onChange={(event: React.FormEvent<HTMLElement>): void => {
           const target = event.target as HTMLInputElement;
           setStaticValue(target.value);

--- a/client/src/components/mapping/TabColumnPicking/StaticValueForm/index.tsx
+++ b/client/src/components/mapping/TabColumnPicking/StaticValueForm/index.tsx
@@ -153,6 +153,47 @@ const StaticValueForm = ({ attribute }: Props): React.ReactElement => {
     }
   };
 
+  const renderReferenceTypeDropDown = (): React.ReactElement => (
+    <React.Fragment>
+      <StringSelect
+        items={
+          loadingFhirTypes || !dataFhirTypes
+            ? []
+            : dataFhirTypes.structureDefinitions.map((t: any) => t.name)
+        }
+        onChange={setStaticValue}
+        loading={loadingFhirTypes}
+        inputItem={staticValue}
+      />
+      <Button
+        disabled={staticValue.length === 0}
+        icon={'add'}
+        loading={creatingStaticInput}
+        onClick={() => addStaticValue(staticValue)}
+      />
+    </React.Fragment>
+  );
+
+  const renderTextInput = (): React.ReactElement => (
+    <React.Fragment>
+      <InputGroup
+        id="static-value-input"
+        onChange={(event: React.FormEvent<HTMLElement>): void => {
+          const target = event.target as HTMLInputElement;
+          setStaticValue(target.value);
+        }}
+        placeholder="Static input"
+        value={staticValue}
+      />
+      <Button
+        disabled={staticValue.length === 0}
+        icon={'add'}
+        loading={creatingStaticInput}
+        onClick={() => addStaticValue(staticValue)}
+      />
+    </React.Fragment>
+  );
+
   return (
     <Card elevation={Elevation.ONE}>
       <div className="card-absolute">
@@ -163,24 +204,7 @@ const StaticValueForm = ({ attribute }: Props): React.ReactElement => {
       <FormGroup labelFor="text-input" inline={true}>
         <ControlGroup>
           {attribute.definition.id === 'Reference.type' ? (
-            <>
-              <StringSelect
-                items={
-                  loadingFhirTypes || !dataFhirTypes
-                    ? []
-                    : dataFhirTypes.structureDefinitions.map((t: any) => t.name)
-                }
-                onChange={setStaticValue}
-                loading={loadingFhirTypes}
-                inputItem={staticValue}
-              />
-              <Button
-                disabled={staticValue.length === 0}
-                icon={'add'}
-                loading={creatingStaticInput}
-                onClick={() => addStaticValue(staticValue)}
-              />
-            </>
+            renderReferenceTypeDropDown()
           ) : attribute.definition.id === 'Identifier.system' ? (
             <IdentifierSystemInput
               attribute={attribute}
@@ -189,23 +213,7 @@ const StaticValueForm = ({ attribute }: Props): React.ReactElement => {
               addStaticValue={addStaticValue}
             />
           ) : (
-            <>
-              <InputGroup
-                id="static-value-input"
-                onChange={(event: React.FormEvent<HTMLElement>): void => {
-                  const target = event.target as HTMLInputElement;
-                  setStaticValue(target.value);
-                }}
-                placeholder="Static input"
-                value={staticValue}
-              />
-              <Button
-                disabled={staticValue.length === 0}
-                icon={'add'}
-                loading={creatingStaticInput}
-                onClick={() => addStaticValue(staticValue)}
-              />
-            </>
+            renderTextInput()
           )}
         </ControlGroup>
       </FormGroup>

--- a/client/src/components/mapping/TabColumnPicking/StaticValueForm/index.tsx
+++ b/client/src/components/mapping/TabColumnPicking/StaticValueForm/index.tsx
@@ -56,7 +56,9 @@ const StaticValueForm = ({ attribute }: Props): React.ReactElement => {
   ] = useLazyQuery(qBasicFhirTypes, {
     fetchPolicy: 'cache-first'
   });
-  const { data: dataSources } = useQuery(qSourcesAndResources);
+  const { data: dataSources } = useQuery(qSourcesAndResources, {
+    fetchPolicy: 'no-cache'
+  });
 
   const sources = dataSources ? dataSources.sources : [];
   const path = attribute.path;

--- a/client/src/components/mapping/TabColumnPicking/StaticValueForm/index.tsx
+++ b/client/src/components/mapping/TabColumnPicking/StaticValueForm/index.tsx
@@ -55,18 +55,23 @@ const StaticValueForm = ({ attribute }: Props) => {
   const dispatch = useDispatch();
 
   const toaster = useSelector((state: IReduxStore) => state.toaster);
-  const { resource } = useSelector((state: IReduxStore) => state.selectedNode);
+  const { source, resource } = useSelector(
+    (state: IReduxStore) => state.selectedNode
+  );
   const attributesForResource = useSelector(
     (state: IReduxStore) => state.resourceInputs.attributesMap
   );
 
+  // If the current attribute is the identifier of the resource and not a Reference identifier
+  const isIdentifierSystem = /^identifier\[\d+\]\.system$/.test(attribute.path);
+
   const [staticValue, setStaticValue] = useState('');
   const [customSystem, setCustomSystem] = useState(false);
   const [selectedSource, setSelectedSource] = useState(
-    undefined as Source | undefined
+    isIdentifierSystem ? source : (undefined as Source | undefined)
   );
   const [selectedResource, setSelectedResource] = useState(
-    undefined as Resource | undefined
+    isIdentifierSystem ? resource : (undefined as Resource | undefined)
   );
 
   const [
@@ -204,22 +209,13 @@ const StaticValueForm = ({ attribute }: Props) => {
             items={sources}
             onChange={handleSourceSelect}
             inputItem={selectedSource || ({} as Source)}
-          >
-            <Button
-              icon="database"
-              rightIcon="caret-down"
-              text={
-                selectedSource
-                  ? `${selectedSource.name} (${selectedSource.template.name})`
-                  : '(Select a source)'
-              }
-            />
-          </SourceSelect>
+            disabled={isIdentifierSystem}
+          />
           <ResourceSelect
             items={selectedSource?.resources || []}
             onChange={handleResourceSelect}
             inputItem={selectedResource || ({} as Resource)}
-            disabled={selectedSource === undefined}
+            disabled={selectedSource === undefined || isIdentifierSystem}
           />
         </>
       ) : (

--- a/client/src/components/mapping/TabColumnPicking/StaticValueForm/index.tsx
+++ b/client/src/components/mapping/TabColumnPicking/StaticValueForm/index.tsx
@@ -5,7 +5,9 @@ import {
   ControlGroup,
   Elevation,
   FormGroup,
-  InputGroup
+  InputGroup,
+  Popover,
+  Position
 } from '@blueprintjs/core';
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -68,10 +70,10 @@ const StaticValueForm = ({ attribute }: Props) => {
   const [staticValue, setStaticValue] = useState('');
   const [customSystem, setCustomSystem] = useState(false);
   const [selectedSource, setSelectedSource] = useState(
-    isIdentifierSystem ? source : (undefined as Source | undefined)
+    undefined as Source | undefined
   );
   const [selectedResource, setSelectedResource] = useState(
-    isIdentifierSystem ? resource : (undefined as Resource | undefined)
+    undefined as Resource | undefined
   );
 
   const [
@@ -92,6 +94,13 @@ const StaticValueForm = ({ attribute }: Props) => {
     if (attribute.isReferenceType) {
       setStaticValue('');
       getFhirTypes();
+    }
+    if (isIdentifierSystem) {
+      setSelectedSource(source);
+      setSelectedResource(resource);
+    } else {
+      setSelectedSource(undefined);
+      setSelectedResource(undefined);
     }
   }, [attribute]);
 
@@ -235,6 +244,27 @@ const StaticValueForm = ({ attribute }: Props) => {
         label="Custom system"
         onChange={(): void => setCustomSystem(!customSystem)}
       />
+      <Popover
+        interactionKind="hover"
+        boundary="viewport"
+        className="help-popover"
+        position={Position.BOTTOM_RIGHT}
+      >
+        <Button icon="help" minimal={true} small={true} />
+        {
+          <div>
+            <p className="text">
+              The identifier system is a URI that defines a set of identifiers
+              (i.e. how the value is made unique). For istance, we use
+              "http://hl7.org/fhir/sid/us-ssn" for United States Social Security
+              Number (SSN) identifier values. Sometimes, the identifiers are not
+              a recognized standard so we need to use a custom system. Pyrog's
+              custom systems have the form
+              "http://terminology.arkhn.org/sourceId/resourceId".
+            </p>
+          </div>
+        }
+      </Popover>
     </ControlGroup>
   );
 

--- a/client/src/components/mapping/TabColumnPicking/style.scss
+++ b/client/src/components/mapping/TabColumnPicking/style.scss
@@ -39,4 +39,9 @@
     position: absolute;
     top: -7px;
   }
+
+  .custom-checkbox {
+    margin: auto;
+    margin-left: 8px;
+  }
 }

--- a/client/src/components/mapping/TabColumnPicking/style.scss
+++ b/client/src/components/mapping/TabColumnPicking/style.scss
@@ -44,4 +44,20 @@
     margin: auto;
     margin-left: 8px;
   }
+
+  .help-popover {
+    margin-left: 8px;
+
+    .bp3-popover-target {
+      vertical-align: sub;
+    }
+  }
+}
+
+.bp3-popover-content {
+
+  .text {
+    width: min-content;
+    margin: 5px;
+  }
 }

--- a/client/src/components/selects/resourceMultiSelect.tsx
+++ b/client/src/components/selects/resourceMultiSelect.tsx
@@ -1,0 +1,69 @@
+import { MenuItem } from '@blueprintjs/core';
+import { ItemPredicate, MultiSelect } from '@blueprintjs/select';
+import React from 'react';
+
+interface Props {
+  resources: Resource[];
+  selectedResources: Resource[];
+  onResourceSelect: (item: Resource) => void;
+  onRemoveTag?: (item: string, ind: number) => void;
+}
+
+interface Resource {
+  id: string;
+  label: string;
+  definitionId: string;
+}
+
+const ResourceMultiSelect = ({
+  resources,
+  selectedResources,
+  onResourceSelect,
+  onRemoveTag
+}: Props): React.ReactElement => {
+  const CustomSelect = MultiSelect.ofType<Resource>();
+
+  const isItemSelected = (list: any[], item: any): boolean => {
+    return list.includes(item);
+  };
+
+  const renderResource = (resource: Resource, { handleClick }: any) => (
+    <MenuItem
+      key={resource.id}
+      text={resource.definitionId}
+      label={resource.label}
+      icon={isItemSelected(selectedResources, resource) ? 'tick' : 'blank'}
+      onClick={handleClick}
+      shouldDismissPopover={false}
+    />
+  );
+
+  const filterResources: ItemPredicate<Resource> = (query, source) => {
+    return source.definitionId.toLowerCase().indexOf(query.toLowerCase()) >= 0;
+  };
+
+  return (
+    <CustomSelect
+      items={resources}
+      tagRenderer={resource => resource.definitionId}
+      tagInputProps={{
+        onRemove: onRemoveTag
+      }}
+      itemRenderer={renderResource}
+      itemPredicate={filterResources}
+      onItemSelect={onResourceSelect}
+      resetOnSelect={true}
+      selectedItems={selectedResources}
+      itemsEqual="id"
+      fill={true}
+      noResults={
+        <MenuItem
+          disabled={true}
+          text="No resources for the selected source."
+        />
+      }
+    />
+  );
+};
+
+export default ResourceMultiSelect;

--- a/client/src/components/selects/resourceSelect.tsx
+++ b/client/src/components/selects/resourceSelect.tsx
@@ -52,7 +52,9 @@ export default class ResourceSelect extends React.Component<SelectProps, any> {
     });
 
   private displayItem = function(resource: Resource): string {
-    return resource.definition ? resource.definition.name : 'None';
+    return resource.definition
+      ? resource.definition.name
+      : '(Select a resource)';
   };
 
   public render() {

--- a/client/src/components/selects/sourceSelect.tsx
+++ b/client/src/components/selects/sourceSelect.tsx
@@ -5,37 +5,45 @@ import { IconName } from '@blueprintjs/icons';
 
 import TSelect from './TSelect';
 
-interface ISource {
+interface Source {
   id: string;
   name: string;
+  template: {
+    name: string;
+  };
 }
 
-interface ISelectProps {
+interface SelectProps {
   disabled?: boolean;
   icon?: IconName;
-  inputItem: ISource;
+  inputItem: Source;
   intent?: Intent;
-  items: ISource[];
+  items: Source[];
   loading?: boolean;
   onChange: any;
 }
 
-export default class SourceSelect extends React.Component<ISelectProps, any> {
-  private renderItem: ItemRenderer<ISource> = (
-    source: ISource,
-    { handleClick, modifiers, query }
+export default class SourceSelect extends React.Component<SelectProps, any> {
+  private renderItem: ItemRenderer<Source> = (
+    source: Source,
+    { handleClick }
   ) => {
     return (
-      <MenuItem key={source.id} onClick={handleClick} text={source.name} />
+      <MenuItem
+        key={source.id}
+        onClick={handleClick}
+        text={source.name}
+        label={source.template.name}
+      />
     );
   };
 
-  private filterByName: ItemPredicate<ISource> = (query, source: ISource) => {
+  private filterByName: ItemPredicate<Source> = (query, source: Source) => {
     return `${source.name.toLowerCase()}`.indexOf(query.toLowerCase()) >= 0;
   };
 
-  private displayItem = function(source: ISource): string {
-    return source.name ? source.name : 'None';
+  private displayItem = function(source: Source): string {
+    return source.name ? source.name : '(Select a source)';
   };
 
   public render() {
@@ -50,7 +58,7 @@ export default class SourceSelect extends React.Component<ISelectProps, any> {
     } = this.props;
 
     return (
-      <TSelect<ISource>
+      <TSelect<Source>
         disabled={!!disabled}
         displayItem={this.displayItem}
         filterItems={this.filterByName}

--- a/client/src/graphql/queries/sourcesAndResources.graphql
+++ b/client/src/graphql/queries/sourcesAndResources.graphql
@@ -13,6 +13,9 @@ query sourcesAndResources {
       id
       label
       definitionId
+      definition {
+        name
+      }
     }
   }
 }

--- a/client/src/types.tsx
+++ b/client/src/types.tsx
@@ -33,6 +33,7 @@ export interface ISelectedSource {
     id: string;
   };
   schema?: ISourceSchema;
+  resources: Resource[];
 }
 
 export interface Profile {

--- a/client/src/types.tsx
+++ b/client/src/types.tsx
@@ -52,6 +52,7 @@ export interface Resource {
   primaryKeyTable: string;
   primaryKeyColumn: string;
   filters: Filters[];
+  definitionId: string;
   definition: {
     id: string;
     type: string;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -52,9 +52,9 @@
     tslib "^1.10.0"
 
 "@arkhn/fhir.ts@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@arkhn/fhir.ts/-/fhir.ts-3.0.0.tgz#4b6358a462af695d865ac119fb2899a7b370d3cb"
-  integrity sha512-lJayJOaQKufQ9K/Z6HPTf90q6wPNKWEqIF0Ts2zkLm4bLiKk0yfk9MW4zQYvy97xw2Nf8QXZH7i+/8LtW8VpHQ==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@arkhn/fhir.ts/-/fhir.ts-3.1.0.tgz#9bd8cc7f410561663a246796be7cc521dcd053ce"
+  integrity sha512-MVNZh+xGZ+nRJkuvsMSd/1mqya3Cs3wGC2R/2EfWztn485hKZMZe9qmwfbE8E8OX/ZU4FaSdlPjDBUhqPUi3Rw==
 
 "@babel/code-frame@7.5.5":
   version "7.5.5"

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -13,9 +13,9 @@
     sleep-promise "^8.0.1"
 
 "@arkhn/fhir.ts@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@arkhn/fhir.ts/-/fhir.ts-3.0.0.tgz#4b6358a462af695d865ac119fb2899a7b370d3cb"
-  integrity sha512-lJayJOaQKufQ9K/Z6HPTf90q6wPNKWEqIF0Ts2zkLm4bLiKk0yfk9MW4zQYvy97xw2Nf8QXZH7i+/8LtW8VpHQ==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@arkhn/fhir.ts/-/fhir.ts-3.1.0.tgz#9bd8cc7f410561663a246796be7cc521dcd053ce"
+  integrity sha512-MVNZh+xGZ+nRJkuvsMSd/1mqya3Cs3wGC2R/2EfWztn485hKZMZe9qmwfbE8E8OX/ZU4FaSdlPjDBUhqPUi3Rw==
 
 "@babel/code-frame@^7.0.0":
   version "7.5.5"


### PR DESCRIPTION
It's now possible to add a custom identifier system in the mapping.
This custom system will look like "http://terminology.arkhn.org/sourceId/resourceId".
The mapper now can select source and resource that will be used as a referential to disambiguate references whose value do not belong to a standard system.

![Capture d’écran 2020-03-31 à 11 35 12](https://user-images.githubusercontent.com/19286277/78011386-ce568080-7343-11ea-9ae7-e4864585f062.png)

![Capture d’écran 2020-03-31 à 11 35 20](https://user-images.githubusercontent.com/19286277/78011405-d3b3cb00-7343-11ea-9b80-d1e7b7300791.png)
