### PR TITLE
Fix bug ref type dropdown

### DIFF
--- a/client/src/components/mapping/TabColumnPicking/StaticValueForm/index.tsx
+++ b/client/src/components/mapping/TabColumnPicking/StaticValueForm/index.tsx
@@ -67,7 +67,7 @@ const StaticValueForm = ({ attribute }: Props): React.ReactElement => {
     : null;
 
   useEffect(() => {
-    if (attribute.isReferenceType) {
+    if (attribute.definition.id === 'Reference.type') {
       setStaticValue('');
       getFhirTypes();
     }

--- a/client/src/components/mapping/TabColumnPicking/StaticValueForm/index.tsx
+++ b/client/src/components/mapping/TabColumnPicking/StaticValueForm/index.tsx
@@ -67,6 +67,8 @@ const StaticValueForm = ({ attribute }: Props): React.ReactElement => {
     : null;
 
   useEffect(() => {
+    // TODO we should use attribute.isReferenceType here but Attribute objects
+    // lose their accessors in Redux
     if (attribute.definition.id === 'Reference.type') {
       setStaticValue('');
       getFhirTypes();


### PR DESCRIPTION
The real problem is a bit deeper: it's the fact that Attribute objects stored in Redux lose their accessors.
This is a temporary fix and we should go back to using accessors when we've found how to do so.