### PR TITLE
Ignore source id when importing a mapping

### DIFF
--- a/server/src/resolvers/Source.ts
+++ b/server/src/resolvers/Source.ts
@@ -97,7 +97,6 @@ export const createSource: FieldResolver<'Mutation', 'createSource'> = async (
   }
   const source = await ctx.prisma.source.create({
     data: {
-      id: parsedMapping ? parsedMapping.source.id : undefined,
       name,
       template: { connect: { name: templateName } },
     },


### PR DESCRIPTION
Id should be ignore when importing a mapping otherwise we can't "copy" a mapping in the same environment.