### PR TITLE
Crash when failing to bootstrap definitions

### DIFF
--- a/server/src/fhir/definitions.ts
+++ b/server/src/fhir/definitions.ts
@@ -90,6 +90,9 @@ export const bootstrapDefinitions = async () => {
       },
     },
   )
+  if (!standardDefinitions.entry || standardDefinitions.entry.length === 0)
+    throw new Error('Could not fetch definitions from fhir-api, aborting...')
+
   await Promise.all(
     standardDefinitions.entry.map(({ resource }: any) =>
       cacheDefinition(resource),


### PR DESCRIPTION
## Fixes

When pyrog retrieves an empty list of StructureDefinition on bootstrap, we want it to crash and exit (this way we can have a restart: always in docker-compose). Usually it happens when definitions are not yet seeded in fhir-api, so we want to retry.
