### PR TITLE
[docker] add src/ to pyrog-server docker image (required by scripts)

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -27,6 +27,7 @@ WORKDIR /srv
 COPY ["package.json",  "tsconfig.json", "tsconfig.build.json", "docker-entrypoint.sh", "/srv/"]
 COPY prisma prisma
 COPY scripts scripts
+COPY src src
 
 COPY --from=build-image /build/node_modules ./node_modules
 COPY --from=build-image /build/dist ./dist


### PR DESCRIPTION
I noticed we could not run scripts using ts-node from within the docker container because the src/ folder was missing.

## Tests

- [x] tried locally