### PR TITLE
disable ACL in test environment

### DIFF
--- a/server/src/constants/index.ts
+++ b/server/src/constants/index.ts
@@ -1,3 +1,5 @@
+import { User } from '@prisma/client'
+
 export const {
   APP_SECRET,
   ENV,
@@ -25,3 +27,10 @@ export const MAPPING_VERSION_9 = 9
 export const CURRENT_MAPPING_VERSION = MAPPING_VERSION_9
 
 export const HL7_AUTHOR = 'HL7'
+
+export const TEST_ADMIN_USER = {
+  id: 'admin',
+  name: 'admin',
+  email: 'admin@arkhn.com',
+  role: 'ADMIN',
+} as User

--- a/server/src/resolvers/Source.ts
+++ b/server/src/resolvers/Source.ts
@@ -8,7 +8,6 @@ import {
   InputGroupWithInputs,
 } from 'types'
 import { Comment, Condition, Input } from '@prisma/client'
-import { IN_PROD } from '../constants'
 
 export const Source = objectType({
   name: 'Source',

--- a/server/src/resolvers/Source.ts
+++ b/server/src/resolvers/Source.ts
@@ -104,15 +104,13 @@ export const createSource: FieldResolver<'Mutation', 'createSource'> = async (
   })
 
   // create a row in ACL
-  if (IN_PROD) {
-    await ctx.prisma.accessControl.create({
-      data: {
-        user: { connect: { id: ctx.user!.id } },
-        source: { connect: { id: source.id } },
-        role: 'WRITER',
-      },
-    })
-  }
+  await ctx.prisma.accessControl.create({
+    data: {
+      user: { connect: { id: ctx.user!.id } },
+      source: { connect: { id: source.id } },
+      role: 'WRITER',
+    },
+  })
 
   // import mapping if present
   if (parsedMapping) {

--- a/server/src/resolvers/Source.ts
+++ b/server/src/resolvers/Source.ts
@@ -8,6 +8,7 @@ import {
   InputGroupWithInputs,
 } from 'types'
 import { Comment, Condition, Input } from '@prisma/client'
+import { IN_PROD } from '../constants'
 
 export const Source = objectType({
   name: 'Source',
@@ -103,13 +104,15 @@ export const createSource: FieldResolver<'Mutation', 'createSource'> = async (
   })
 
   // create a row in ACL
-  await ctx.prisma.accessControl.create({
-    data: {
-      user: { connect: { id: ctx.user!.id } },
-      source: { connect: { id: source.id } },
-      role: 'WRITER',
-    },
-  })
+  if (IN_PROD) {
+    await ctx.prisma.accessControl.create({
+      data: {
+        user: { connect: { id: ctx.user!.id } },
+        source: { connect: { id: source.id } },
+        role: 'WRITER',
+      },
+    })
+  }
 
   // import mapping if present
   if (parsedMapping) {

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -20,12 +20,12 @@ export const getUser = async (
 ): Promise<User | null> => {
   if (!IN_PROD) {
     // insert a fake admin user for tests
-    await prisma.user.upsert({
+    const user = prisma.user.upsert({
       where: { id: TEST_ADMIN_USER.id },
       create: TEST_ADMIN_USER,
       update: TEST_ADMIN_USER,
     })
-    return TEST_ADMIN_USER
+    return user
   }
 
   const authorization = request.get('Authorization')

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -11,15 +11,22 @@ import {
   IN_PROD,
   TOKEN_INTROSPECTION_URL,
   USER_INFO_URL,
+  TEST_ADMIN_USER,
 } from './constants'
 
 export const getUser = async (
   request: Request,
   prisma: PrismaClient,
 ): Promise<User | null> => {
-  if (!IN_PROD)
-    // return a fake user for tests
-    return { id: 'admin', name: 'admin', email: 'admin', role: 'ADMIN' } as User
+  if (!IN_PROD) {
+    // insert a fake admin user for tests
+    await prisma.user.upsert({
+      where: { id: TEST_ADMIN_USER.id },
+      create: TEST_ADMIN_USER,
+      update: TEST_ADMIN_USER,
+    })
+    return TEST_ADMIN_USER
+  }
 
   const authorization = request.get('Authorization')
   const idToken = request.get('IdToken')


### PR DESCRIPTION
In the context of E2E tests, there is no user in the pyrog DB, hence we cannot create an ACL row to connect to the user creating the source.

I'm wondering if I should implement the whole authentication workflow in E2E tests to go around this issue, what's your opinion ?
