### PR TITLE
Don't override authorization header if already present

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -99,8 +99,10 @@ const redirectToLogin = () => {
 
 // Set axios interceptor
 axios.interceptors.request.use(config => {
-  const accessToken = localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY);
-  config.headers.Authorization = `Bearer ${accessToken}`;
+  if (!config.headers.Authorization) {
+    const accessToken = localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY);
+    config.headers.Authorization = `Bearer ${accessToken}`;
+  }
   return config;
 });
 


### PR DESCRIPTION
## Fixes
A error was returned by Hydra when trying to revoke a token because the auth header was being overidden by the interceptor?